### PR TITLE
Fix Globbing on Windows; add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# Specific to this repo
+*.mp3

--- a/mp3cat.go
+++ b/mp3cat.go
@@ -85,7 +85,20 @@ func main() {
 	} else if len(parser.Args) > 0 {
 		for _, pattern := range parser.Args {
 			matches, _ := filepath.Glob(pattern)
-			files = append(files, matches...)
+			for _, match := range matches {
+				// to only add files not already matched
+				seen := false
+				for _, file := range files {
+					if file == match {
+						seen = true
+						break
+					}
+				}
+				if !seen {
+					files = append(files, match)
+					// fmt.Println("Found new file:", match)
+				}
+			}
 		}
 	} else {
 		fmt.Fprintln(os.Stderr, "Error: you must specify files to merge.")

--- a/mp3cat.go
+++ b/mp3cat.go
@@ -83,7 +83,10 @@ func main() {
 			os.Exit(1)
 		}
 	} else if len(parser.Args) > 0 {
-		files = parser.Args
+		for _, pattern := range parser.Args {
+			matches, _ := filepath.Glob(pattern)
+			files = append(files, matches...)
+		}
 	} else {
 		fmt.Fprintln(os.Stderr, "Error: you must specify files to merge.")
 		os.Exit(1)


### PR DESCRIPTION
## Changes

* Fix Globbing by manually evaluating files with Go's Glob functionality
* Do not match duplicate files
* Add specific to this repo .gitignore (ignores `.mp3`s for git) 

## Demo (v2)

```

C:\mp3>ver

Microsoft Windows [Version 10.0.19044.4780]

C:\mp3>dir /w
 Volume in drive C has no label.
 Volume Serial Number is 6A3E-D67E

 Directory of C:\mp3

[.]                             [..]                            00.mp3
01.mp3                          02.mp3                          03.mp3
04.mp3                          05.mp3                          06.mp3
07.mp3                          08.mp3                          09.mp3
10.mp3                          11.mp3                          12.mp3
13.mp3                          14.mp3                          15.mp3
16.mp3                          17.mp3                          18.mp3
19.mp3                          20.mp3                          21.mp3
22.mp3                          23.mp3                          24.mp3
25.mp3                          26.mp3                          27.mp3
28.mp3                          29.mp3                          30.mp3
31.mp3                          32.mp3                          33.mp3
34.mp3                          35.mp3                          36.mp3
37.mp3                          38.mp3                          39.mp3
40.mp3                          41.mp3                          42.mp3
43.mp3                          44.mp3                          45.mp3
46.mp3                          47.mp3                          cover.jpg
mp3cat-improved-TAbdiukov.exe
              50 File(s)    398.238.306 bytes
               2 Dir(s)  37.585.575.936 bytes free

C:\mp3>echo "Let's say I want to merge only files that are 3*.mp3 and *7.mp3"
"Let's say I want to merge only files that are 3*.mp3 and *7.mp3"

C:\mp3>mp3cat-improved-TAbdiukov.exe 3*.mp3 *7.mp3 -o output.mp3
------------------------------------------------------------------------------------------------------------------------
+ 30.mp3
+ 31.mp3
+ 32.mp3
+ 33.mp3
+ 34.mp3
+ 35.mp3
+ 36.mp3
+ 37.mp3
+ 38.mp3
+ 39.mp3
+ 07.mp3
+ 17.mp3
+ 27.mp3
+ 47.mp3
------------------------------------------------------------------------------------------------------------------------
• Multiple bitrates detected. Adding VBR header.
• 14 files merged.
------------------------------------------------------------------------------------------------------------------------

C:\mp3>
```